### PR TITLE
Fix CLI command alignment in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,30 +53,30 @@ Usage:
 
 Commands:
 
-  install        Install BrowserBox + bbx CLI
-  uninstall      Remove everything
-  activate       Purchase a license						bbx activate [number of people]
-  setup          Configure options 						bbx setup [--port|-p <p>] [--hostname|-h <h>] [--token|-t <t>] [--zeta|-z]
+  install      Install BrowserBox + bbx CLI
+  uninstall    Remove everything
+  activate     Purchase a license                   bbx activate [number of people]
+  setup        Configure options                    bbx setup [--port|-p <p>] [--hostname|-h <h>] [--token|-t <t>] [--zeta|-z]
 
-  		   setup options:
-         	         --zeta, -z       Expose each service as a unique hostname. Useful for nginx,
-         	                          ngrok, similar layers, or standard HTTP/S ports. Expects hosts.env
-  certify        Check your license
-  run            Run BrowserBox 			       		bbx run [--port|-p <port>] [--hostname|-h <hostname>]
-  stop           Stop BrowserBox (current user)
-  run-as         Run as a specific user 		    	bbx run-as [--temporary] [username] [port]
-  stop-user      Stop BrowserBox for a specific user 	bbx stop-user <username> [delay_seconds]
-  logs           Show BrowserBox logs
-  update         Update BrowserBox       		       	bbx update [<version>|--latest-rc]
-  status         Check BrowserBox status
-  tor-run        Run BrowserBox on Tor      			bbx tor-run [--no-darkweb] [--no-onion]
-  zt-run         Run BrowserBox with ZeroTier tunnel	bbx zt-run
-  docker-run     Run BrowserBox using Docker 			bbx docker-run [nickname] [--port|-p <port>]
-  docker-stop    Stop a Dockerized BrowserBox 			bbx docker-stop <nickname>
-  automate      *Drive with script, MCP or REPL
-  ng-run         Run BrowserBox with Nginx proxy		bbx ng-run
-  --version      Show version
-  --help         Show this help
+    setup options:
+      --zeta, -z  Expose each service as a unique hostname. Useful for nginx,
+                  ngrok, similar layers, or standard HTTP/S ports. Expects hosts.env
+  certify      Check your license
+  run          Run BrowserBox                       bbx run [--port|-p <port>] [--hostname|-h <hostname>]
+  stop         Stop BrowserBox (current user)
+  run-as       Run as a specific user               bbx run-as [--temporary] [username] [port]
+  stop-user    Stop BrowserBox for a specific user  bbx stop-user <username> [delay_seconds]
+  logs         Show BrowserBox logs
+  update       Update BrowserBox                    bbx update [<version>|--latest-rc]
+  status       Check BrowserBox status
+  tor-run      Run BrowserBox on Tor                bbx tor-run [--no-darkweb] [--no-onion]
+  zt-run       Run BrowserBox with ZeroTier tunnel  bbx zt-run
+  docker-run   Run BrowserBox using Docker          bbx docker-run [nickname] [--port|-p <port>]
+  docker-stop  Stop a Dockerized BrowserBox         bbx docker-stop <nickname>
+  automate     *Drive with script, MCP or REPL
+  ng-run       Run BrowserBox with Nginx proxy      bbx ng-run
+  --version    Show version
+  --help       Show this help
 
 *automate coming soon
 ```


### PR DESCRIPTION
## Summary
- align the CLI command list in the ANSI README block so the columns line up consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f23010e330832092f92436ff3495fa